### PR TITLE
feat: ローカルユーザーのJPEGアップロード時にEXIF等のメタデータを除去

### DIFF
--- a/packages/backend/src/core/CoreModule.ts
+++ b/packages/backend/src/core/CoreModule.ts
@@ -154,6 +154,8 @@ import { ApQuestionService } from './activitypub/models/ApQuestionService.js';
 import { QueueModule } from './QueueModule.js';
 import { QueueService } from './QueueService.js';
 import { LoggerService } from './LoggerService.js';
+import { MediaMetadataStripService } from './media-metadata-strip/MediaMetadataStripService.js';
+import { JpegMetadataStripper } from './media-metadata-strip/JpegMetadataStripper.js';
 import type { Provider } from '@nestjs/common';
 
 //#region 文字列ベースでのinjection用(循環参照対応のため)
@@ -459,6 +461,9 @@ const $ApQuestionService: Provider = { provide: 'ApQuestionService', useExisting
 		ApQuestionService,
 		QueueService,
 
+		MediaMetadataStripService,
+		JpegMetadataStripper,
+
 		//#region 文字列ベースでのinjection用(循環参照対応のため)
 		$LoggerService,
 		$AbuseReportService,
@@ -757,6 +762,9 @@ const $ApQuestionService: Provider = { provide: 'ApQuestionService', useExisting
 		ApPersonService,
 		ApQuestionService,
 		QueueService,
+
+		MediaMetadataStripService,
+		JpegMetadataStripper,
 
 		//#region 文字列ベースでのinjection用(循環参照対応のため)
 		$LoggerService,

--- a/packages/backend/src/core/DriveService.ts
+++ b/packages/backend/src/core/DriveService.ts
@@ -43,6 +43,7 @@ import { correctFilename } from '@/misc/correct-filename.js';
 import { isMimeImage } from '@/misc/is-mime-image.js';
 import { ModerationLogService } from '@/core/ModerationLogService.js';
 import { UtilityService } from '@/core/UtilityService.js';
+import { MediaMetadataStripService } from '@/core/media-metadata-strip/MediaMetadataStripService.js';
 
 type AddFileArgs = {
 	/** User who wish to add file */
@@ -130,6 +131,7 @@ export class DriveService {
 		private perUserDriveChart: PerUserDriveChart,
 		private instanceChart: InstanceChart,
 		private utilityService: UtilityService,
+		private mediaMetadataStripService: MediaMetadataStripService,
 	) {
 		const logger = new Logger('drive', 'blue');
 		this.registerLogger = logger.createSubLogger('register', 'yellow');
@@ -467,6 +469,10 @@ export class DriveService {
 		if (this.meta.sensitiveMediaDetection === 'none') skipNsfwCheck = true;
 		if (user && this.meta.sensitiveMediaDetection === 'local' && this.userEntityService.isRemoteUser(user)) skipNsfwCheck = true;
 		if (user && this.meta.sensitiveMediaDetection === 'remote' && this.userEntityService.isLocalUser(user)) skipNsfwCheck = true;
+
+		if (user && this.userEntityService.isLocalUser(user)) {
+			await this.mediaMetadataStripService.strip(path);
+		}
 
 		const info = await this.fileInfoService.getFileInfo(path, {
 			fileName: name,

--- a/packages/backend/src/core/media-metadata-strip/JpegMetadataStripper.ts
+++ b/packages/backend/src/core/media-metadata-strip/JpegMetadataStripper.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import * as fs from 'node:fs';
 import { Injectable } from '@nestjs/common';
 import sharp from 'sharp';
 import { bindThis } from '@/decorators.js';
@@ -14,18 +13,11 @@ export class JpegMetadataStripper implements MetadataStripper {
 	public readonly mime = 'image/jpeg';
 
 	@bindThis
-	public async strip(path: string): Promise<void> {
-		const tmpPath = `${path}.stripped`;
-		try {
-			await sharp(path)
-				.rotate()
-				.keepIccProfile()
-				.jpeg({ quality: 95, mozjpeg: true })
-				.toFile(tmpPath);
-			await fs.promises.rename(tmpPath, path);
-		} catch (err) {
-			await fs.promises.unlink(tmpPath).catch(() => {});
-			throw err;
-		}
+	public async strip(srcPath: string, dstPath: string): Promise<void> {
+		await sharp(srcPath)
+			.rotate()
+			.keepIccProfile()
+			.jpeg({ quality: 95, mozjpeg: true })
+			.toFile(dstPath);
 	}
 }

--- a/packages/backend/src/core/media-metadata-strip/JpegMetadataStripper.ts
+++ b/packages/backend/src/core/media-metadata-strip/JpegMetadataStripper.ts
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import * as fs from 'node:fs';
+import { Injectable } from '@nestjs/common';
+import sharp from 'sharp';
+import { bindThis } from '@/decorators.js';
+import type { MetadataStripper } from './MetadataStripper.js';
+
+@Injectable()
+export class JpegMetadataStripper implements MetadataStripper {
+	public readonly mime = 'image/jpeg';
+
+	@bindThis
+	public async strip(path: string): Promise<void> {
+		const tmpPath = `${path}.stripped`;
+		try {
+			await sharp(path)
+				.rotate()
+				.keepIccProfile()
+				.jpeg({ quality: 95, mozjpeg: true })
+				.toFile(tmpPath);
+			await fs.promises.rename(tmpPath, path);
+		} catch (err) {
+			await fs.promises.unlink(tmpPath).catch(() => {});
+			throw err;
+		}
+	}
+}

--- a/packages/backend/src/core/media-metadata-strip/MediaMetadataStripService.ts
+++ b/packages/backend/src/core/media-metadata-strip/MediaMetadataStripService.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import * as fs from 'node:fs';
 import { Injectable } from '@nestjs/common';
 import * as fileType from 'file-type';
 import Logger from '@/logger.js';
@@ -26,13 +27,16 @@ export class MediaMetadataStripService {
 
 	@bindThis
 	public async strip(path: string): Promise<void> {
+		const dstPath = `${path}.stripped`;
 		try {
 			const type = await fileType.fileTypeFromFile(path);
 			if (!type) return;
 			const stripper = this.strippers.get(type.mime);
 			if (!stripper) return;
-			await stripper.strip(path);
+			await stripper.strip(path, dstPath);
+			await fs.promises.rename(dstPath, path);
 		} catch (err) {
+			await fs.promises.unlink(dstPath).catch(() => {});
 			this.logger.warn(`metadata strip failed, continuing with original: ${err}`);
 		}
 	}

--- a/packages/backend/src/core/media-metadata-strip/MediaMetadataStripService.ts
+++ b/packages/backend/src/core/media-metadata-strip/MediaMetadataStripService.ts
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { Injectable } from '@nestjs/common';
+import * as fileType from 'file-type';
+import Logger from '@/logger.js';
+import { bindThis } from '@/decorators.js';
+import { JpegMetadataStripper } from './JpegMetadataStripper.js';
+import type { MetadataStripper } from './MetadataStripper.js';
+
+@Injectable()
+export class MediaMetadataStripService {
+	private readonly logger: Logger;
+	private readonly strippers: Map<string, MetadataStripper>;
+
+	constructor(
+		private jpegMetadataStripper: JpegMetadataStripper,
+	) {
+		this.logger = new Logger('media-metadata-strip', 'gray');
+		this.strippers = new Map<string, MetadataStripper>([
+			[jpegMetadataStripper.mime, jpegMetadataStripper],
+		]);
+	}
+
+	@bindThis
+	public async strip(path: string): Promise<void> {
+		try {
+			const type = await fileType.fileTypeFromFile(path);
+			if (!type) return;
+			const stripper = this.strippers.get(type.mime);
+			if (!stripper) return;
+			await stripper.strip(path);
+		} catch (err) {
+			this.logger.warn(`metadata strip failed, continuing with original: ${err}`);
+		}
+	}
+}

--- a/packages/backend/src/core/media-metadata-strip/MediaMetadataStripService.ts
+++ b/packages/backend/src/core/media-metadata-strip/MediaMetadataStripService.ts
@@ -37,7 +37,7 @@ export class MediaMetadataStripService {
 			await fs.promises.rename(dstPath, path);
 		} catch (err) {
 			await fs.promises.unlink(dstPath).catch(() => {});
-			this.logger.warn(`metadata strip failed, continuing with original: ${err}`);
+			this.logger.warn('metadata strip failed, continuing with original', { e: err });
 		}
 	}
 }

--- a/packages/backend/src/core/media-metadata-strip/MetadataStripper.ts
+++ b/packages/backend/src/core/media-metadata-strip/MetadataStripper.ts
@@ -5,5 +5,9 @@
 
 export interface MetadataStripper {
 	readonly mime: string;
-	strip(path: string): Promise<void>;
+	/**
+	 * Read the file at `srcPath`, strip metadata, and write the result to `dstPath`.
+	 * The caller is responsible for any post-processing such as replacing the original.
+	 */
+	strip(srcPath: string, dstPath: string): Promise<void>;
 }

--- a/packages/backend/src/core/media-metadata-strip/MetadataStripper.ts
+++ b/packages/backend/src/core/media-metadata-strip/MetadataStripper.ts
@@ -1,0 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export interface MetadataStripper {
+	readonly mime: string;
+	strip(path: string): Promise<void>;
+}


### PR DESCRIPTION
## 何をしたのか

ローカルユーザーが Drive に `image/jpeg` をアップロードした際、EXIF/GPS/IPTC/XMP 等のメタデータを除去する仕組みを追加した。

### 実装内容

- `packages/backend/src/core/media-metadata-strip/` 配下に Strategy パターンでサービスを新設
  - `MetadataStripper.ts`: フォーマット別ストリッパの interface
  - `JpegMetadataStripper.ts`: sharp で JPEG を再エンコードしメタデータを除去（`.rotate()` で Orientation 焼き込み、`.keepIccProfile()` で色情報保持、`quality: 95, mozjpeg: true`）
  - `MediaMetadataStripService.ts`: エントリポイント。`file-type` で MIME 判定し対応するストリッパへディスパッチ
- `DriveService.addFile()` 内で `getFileInfo()` 直前にローカルユーザーのファイルに対し `strip()` を呼び出し
- ファイル置換は別tmpに書き出して `fs.rename` で原子的に置換、失敗時は warn ログのみ出してアップロードは継続

## なぜやったのか

ユーザーが意図せず GPS や端末情報といったプライバシー情報を Drive 経由で公開してしまうリスクを軽減するため。
JPEG はスマホ・カメラ写真で最も一般的にメタデータを含むフォーマットであり、まずここから対応する。

関連issue: https://github.com/rockcutter-misskey/misskey_with_like/issues/26

## 設計上のポイント

### upstream とのコンフリクト最小化

本リポジトリは `misskey-dev/misskey` を upstream として取り込む際にコンフリクトしやすいため、

- 本体ロジックは新規ディレクトリに集約（衝突なし）
- 既存ファイルへの変更は **追記のみ計14行**（CoreModule.ts に8行、DriveService.ts に6行）
- `ImageProcessingService.ts` には触らない

### 拡張性

将来的に PNG / WebP / AVIF 等を追加する際は、

1. `XxxMetadataStripper.ts` を新規作成
2. `MediaMetadataStripService` の constructor / Map に追加
3. `CoreModule.ts` に provider 登録

の3ステップで完結し、`DriveService.ts` には触れずに拡張可能。

## 副次的な影響

- MD5 がメタデータ除去後のファイルに対して計算されるため、同一ユーザーが「EXIF だけ違う同一画像」をアップロードした場合に既存ファイルへ集約される
- 既存の Drive ファイルには影響なし。本実装後に新規アップロードされるファイルからのみ適用

## テスト観点

- [ ] GPS 情報入り JPEG → exiftool 等で除去確認
- [ ] Orientation 6（90度回転）等の JPEG → 出力後に正立しているか
- [ ] Display P3 画像 → 色が崩れないか（ICC 保持確認）
- [ ] 壊れた JPEG → 例外を吐かずに元ファイルのままアップロード継続
- [ ] Progressive JPEG / CMYK JPEG → 正常処理
- [ ] PNG / WebP / 動画 → 処理がスキップされる
- [ ] リモートユーザー由来のファイル → 処理がスキップされる
